### PR TITLE
chore: add test-dirty to travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - # skip
 
 script:
-  - make build
+  - make test-dirty
   - make test
 
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,11 @@ test: fmt lint vet test-unit
 test-unit:
 	go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 
+# Make sure go.mod and go.sum are not modified
+.PHONY: test-dirty
+test-dirty: build
+	git diff --exit-code
+
 .PHONY: fmt
 fmt:
 	test -z "$(shell gofmt -l .)"


### PR DESCRIPTION
The new make target "test-dirty" will ensure that the go.mod and go.sum
files are not being changed at build time.