### PR TITLE
chore: update travis-ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/seanmalloy/gsd.svg?branch=master)](https://travis-ci.org/seanmalloy/gsd)
+[![Build Status](https://travis-ci.com/seanmalloy/gsd.svg?branch=master)](https://travis-ci.com/seanmalloy/gsd)
 [![codecov](https://codecov.io/gh/seanmalloy/gsd/branch/master/graph/badge.svg)](https://codecov.io/gh/seanmalloy/gsd)
 
 ## Get Server Data


### PR DESCRIPTION
This project has been migrated from travis-ci.org to travis-ci.com.